### PR TITLE
Streamlined backup endpoint functionality + fixed image endpoint bugs.

### DIFF
--- a/Modules/MainCallers/ZukiChat.js
+++ b/Modules/MainCallers/ZukiChat.js
@@ -2,8 +2,9 @@ import { ZukiChatCall } from "../SubCallers/ZukiChatCall.js";
 
 export class ZukiChat {
 
-    constructor(API_KEY, model = "gpt-3.5", systemPrompt = "You are a helpful assistant.", temperature = 0.7) {
+    constructor(API_KEY, API_BACKUP_KEY = "", model = "gpt-3.5", systemPrompt = "You are a helpful assistant.", temperature = 0.7) {
         this.API_KEY = API_KEY;
+        this.API_BACKUP_KEY = API_BACKUP_KEY;
         this.API_ENDPOINT = 'https://zukijourney.xyzbot.net/v1/chat/completions';
         this.API_ENDPOINT_UNFILTERED = 'https://zukijourney.xyzbot.net/unf/chat/completions';
         this.API_ENDPOINT_BACKUP = 'https://thirdparty.webraft.in/v1/chat/completions'; //A backup endpoint, if appplicable. Usually meant to utilize another API. By default it's set to the WebRaft API due to its rate limit being ideal for testing purposes.
@@ -21,6 +22,7 @@ export class ZukiChat {
         this.temperature = temperature;
 
         this.API_CALLER = new ZukiChatCall(this.API_KEY);
+        this.API_BACKUP_CALLER = new ZukiChatCall(this.API_BACKUP_KEY);
 
     }
 
@@ -88,7 +90,7 @@ export class ZukiChat {
          * Calls the backup API via the backup endpoint.
          */
         
-        return this.API_CALLER.CHAT_CALL(userName, userMessage, this.model, this.systemPrompt, this.temperature, this.API_ENDPOINT_BACKUP);
+        return this.API_BACKUP_CALLER.CHAT_CALL(userName, userMessage, this.model, this.systemPrompt, this.temperature, this.API_ENDPOINT_BACKUP);
 
     }
 

--- a/Modules/MainCallers/ZukiImage.js
+++ b/Modules/MainCallers/ZukiImage.js
@@ -1,13 +1,16 @@
+import { ZukiChatCall } from "../SubCallers/ZukiChatCall.js";
 import { ZukiImageCall } from "../SubCallers/ZukiImageCall.js";
 
 export class ZukiImage {
 
-    constructor(API_KEY) {
+    constructor(API_KEY, API_BACKUP_KEY = "") {
 
         this.API_KEY = API_KEY;
+        this.API_BACKUP_KEY = API_BACKUP_KEY;
         this.API_ENDPOINT = "https://zukijourney.xyzbot.net/v1/images/generations";
         this.API_ENDPOINT_BACKUP = "https://api.webraft.in/api/images/generations";
         this.API_CALLER = new ZukiImageCall(API_KEY);
+        this.API_BACKUP_CALLER = new ZukiImageCall(API_BACKUP_KEY);
 
     }
 
@@ -22,16 +25,16 @@ export class ZukiImage {
     }
 
 
-    async generateImage(prompt, generations = 1, size = 250) {
+    async generateImage(prompt, generations = 1, size = "1024x1024") {
 
         return this.API_CALLER.IMAGE_CALL(prompt, generations, size, this.API_ENDPOINT);
 
     }
 
 
-    async generateBackupImage(prompt, generations = 1, size = 250){
+    async generateBackupImage(prompt, generations = 1, size = "1024x1024"){
 
-        return this.API_CALLER.IMAGE_CALL(prompt, generations, size, this.API_ENDPOINT_BACKUP);
+        return this.API_BACKUP_CALLER.IMAGE_CALL(prompt, generations, size, this.API_ENDPOINT_BACKUP);
 
     }
 

--- a/Modules/SubCallers/ZukiChatCall.js
+++ b/Modules/SubCallers/ZukiChatCall.js
@@ -10,7 +10,7 @@ export class ZukiChatCall{
 
         /** 
          * Gets the actual data object being sent to the API.
-         */
+        */
 
         const data = {
             model: requestedModel, //You can change the model here.
@@ -40,7 +40,7 @@ export class ZukiChatCall{
 
         /**
          * Makes an API call via the desired enpoint.
-         */
+        */
 
         try {
 

--- a/Modules/SubCallers/ZukiImageCall.js
+++ b/Modules/SubCallers/ZukiImageCall.js
@@ -4,7 +4,6 @@ export class ZukiImageCall {
     constructor(API_KEY) {
 
         this.API_KEY = API_KEY;
-
     }
 
     IMAGE_DATA(prompt, generations, size) {

--- a/Modules/ZukiCall.js
+++ b/Modules/ZukiCall.js
@@ -3,12 +3,13 @@ import { ZukiImage } from "./MainCallers/ZukiImage.js";
 
 export class ZukiCall{
 
-    constructor(API_KEY, chatModel = 'gpt-3.5'){
+    constructor(API_KEY, API_BACKUP_KEY = "", chatModel = 'gpt-3.5'){
 
         this.API_KEY = API_KEY;
+        this.API_BACKUP_KEY = API_BACKUP_KEY;
         this.chatModel = chatModel;
-        this.zukiChat = new ZukiChat(API_KEY, chatModel);
-        this.zukiImage = new ZukiImage(API_KEY);
+        this.zukiChat = new ZukiChat(API_KEY, API_BACKUP_KEY, chatModel);
+        this.zukiImage = new ZukiImage(API_KEY, API_BACKUP_KEY);
 
     }
 

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
  * an LLM (in this case GPT-3) and a response is printed to the console.
  */
 
-import { ZukiCall } from "./Modules/ZukiCall.js"; 
+import { ZukiCall } from "./Modules/ZukiCall.js";
 /**
  * You only need to import the ZukiCall class to access the rest of the wrapper. 
  * If JavaScript can't find the folder, make sure you have a package.json file
@@ -18,11 +18,11 @@ const API_BACKUP_KEY = ""; //Set this value to your backup API key, if you have 
 
 //The ZukiCall class handles sending and receiving messages to our LLM with the API.
 
-let zukiAI = new ZukiCall(API_KEY); 
+let zukiAI = new ZukiCall(API_KEY, API_BACKUP_KEY);
 //By default the chat model is gpt-3.5 if the second function parameter is not defined upon intialization.
 //By default the system prompt (third function parameter) is "You are a helpful assistant", this can be changed later with .zukiChat.setSystemPrompt().
 
-let chatResponse = await zukiAI.zukiChat.sendMessage("Sabs", "Hey, how's it going?"); 
+let chatResponse = await zukiAI.zukiChat.sendMessage("Sabs", "Hey, how's it going?");
 /**
  * To call the unfiltered endpoint, use .zukiChat.sendUnfilteredMessage().
  * If you have a backup API endpoint, first set it as a backup using .zukiChat.changeBackupEndpoint("backup-endpoint"),


### PR DESCRIPTION
This merge just fixes the image endpoint bugs since the JSON body needs to have a string value for the "n" parameter when making an API call to it. The ZukiCall class also needs an API key and an API backup key (you can just pass in a blank string) as a parameter.